### PR TITLE
Add /usr/sbin to executable search path

### DIFF
--- a/service/openvpn/client/helper/executable_finder_darwin.go
+++ b/service/openvpn/client/helper/executable_finder_darwin.go
@@ -3,6 +3,7 @@ package helper
 var guessExecutableName = "openvpn"
 var guessExecutablePaths = []string{
 	"/usr/local/sbin/openvpn",
+        "/usr/sbin/openvpn",
 	"/Applications/Tunnelblick.app/Contents/Resources/openvpn/openvpn-2.4.*-openssl-1.*/openvpn",
 	"/Applications/Shimo.app/Contents/MacOS/openvpn",
 	"/Applications/Viscosity.app/Contents/MacOS/openvpn",

--- a/service/openvpn/client/helper/executable_finder_other.go
+++ b/service/openvpn/client/helper/executable_finder_other.go
@@ -6,5 +6,6 @@ package helper
 var guessExecutableName = "openvpn"
 var guessExecutablePaths = []string{
 	"/usr/local/sbin/openvpn",
+	"/usr/sbin/openvpn",
 }
 var guessExecutableSuggestions = ""


### PR DESCRIPTION
Debian installs openvpn in /usr/sbin, which isn't on the normal user's path.